### PR TITLE
Hotfix | Change url to github

### DIFF
--- a/qualifire-reverse-proxy-chart/templates/app/deployment.yaml
+++ b/qualifire-reverse-proxy-chart/templates/app/deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - -c
             - |
               apk add nss-tools curl &&
-              curl --output /etc/caddy/Caddyfile https://pastebin.com/raw/R5rUikQU &&
+              curl --output /etc/caddy/Caddyfile https://raw.githubusercontent.com/qualifire-dev/qualifire-rp-helm/refs/heads/main/caddy_conf/Caddyfile &&
               caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
           volumeMounts:
             - name: app-data-volume

--- a/qualifire-reverse-proxy-chart/templates/proxy/deployment.yaml
+++ b/qualifire-reverse-proxy-chart/templates/proxy/deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - -c
             - |
               apk add nss-tools curl &&
-              curl --output /etc/caddy/Caddyfile https://pastebin.com/raw/R5rUikQU &&
+              curl --output /etc/caddy/Caddyfile https://raw.githubusercontent.com/qualifire-dev/qualifire-rp-helm/refs/heads/main/caddy_conf/Caddyfile &&
               caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
           volumeMounts:
             - name: proxy-data-volume


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the reverse proxy deployment to fetch the web server configuration from a new GitHub-hosted source instead of the previous Pastebin URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->